### PR TITLE
Skip selector calculation of non-violation results

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ if (process.env.NODE_ENV !== 'production') {
 |Key|Description|Default|Required|
 |---|---|---|---|
 |`clearConsoleOnUpdate`|Clears the console each time `vue-axe` runs|`true`|`false`|
-|`config`|Provide your Axe-core configuration: https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure| |`false`|
+|`config`|Provide your Axe-core configuration: [API Name: axe.configure](https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure)| |`false`|
+|`runOptions`|Provide your Axe-core runtime options: [API Name: axe.run](https://github.com/dequelabs/axe-core/blob/master/doc/API.md#options-parameter)|`{ reporter: 'v2', resultTypes: ['violations'] }`|`false`|
 
 ## Install in Nuxt.js
 Create plugin file `plugins/axe.js`

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,10 @@ export default function install (Vue, options) {
 
   options = {
     clearConsoleOnUpdate: true,
+    runOptions: {
+      reporter: 'v2',
+      resultTypes: ['violations']
+    },
     ...options
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,7 @@ export function checkAndReport (options, node) {
   nodes.push(node)
   let deferred = createDeferred()
 
-  axeCore.run(document, { reporter: 'v2' }, (error, results) => {
+  axeCore.run(document, { reporter: 'v2', resultTypes: ['violations'] }, (error, results) => {
     if (error) deferred.reject(error)
     if (!results) return
     if (JSON.stringify(results.violations) === lastNotification) return

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,7 @@ export function checkAndReport (options, node) {
   nodes.push(node)
   let deferred = createDeferred()
 
-  axeCore.run(document, { reporter: 'v2', resultTypes: ['violations'] }, (error, results) => {
+  axeCore.run(document, options.runOptions, (error, results) => {
     if (error) deferred.reject(error)
     if (!results) return
     if (JSON.stringify(results.violations) === lastNotification) return


### PR DESCRIPTION
It takes a very long time to inspect a huge page with a large number of nodes.

According to the official documentation, one of the reasons it takes so long to process is the selector calculation. It takes time because the calculations are performed not only for the items that failed the test, but also for the items that passed the test.
https://github.com/dequelabs/axe-core/blob/master/doc/API.md#section-4-performance

In vue-axe, we only use violations results among all results. The `resultType` should be set to `["violations"]` in order to avoid unnecessary calculations.