### PR TITLE
feat: add custom result handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,26 @@ if (process.env.NODE_ENV !== 'production') {
 |Key|Description|Default|Required|
 |---|---|---|---|
 |`clearConsoleOnUpdate`|Clears the console each time `vue-axe` runs|`true`|`false`|
+|`customResultHandler`|Handle the results from an `axe.run()`. This may be needed for automated tests.|`undefined`|`false`|
 |`config`|Provide your Axe-core configuration: https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure| |`false`|
+
+#### Custom Result Handler
+
+The `customResultHandler` config property expects a callback like the `axe.run()` callback ([see documentation](https://github.com/dequelabs/axe-core/blob/master/doc/API.md#parameters-axerun)). It will be triggered after each call to `axe.run()`. 
+
+```javascript
+import Vue from 'vue'
+
+if (process.env.NODE_ENV !== 'production') {
+  const VueAxe = require('vue-axe')
+  Vue.use(VueAxe, {
+    customResultHandler: (error, results) => {
+      results.violations.forEach(violation => console.log(violation))
+    }
+    // ...
+  })
+}
+``` 
 
 ## Install in Nuxt.js
 Create plugin file `plugins/axe.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -573,9 +573,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.4.1.tgz",
-      "integrity": "sha512-+EhIdwR0hF6aeMx46gFDUy6qyCfsL0DmBrV3Z+LxYbsOd8e1zBaPHa3f9Rbjsz2dEwSBkLw6TwML/CAIIAqRpw=="
+      "version": "3.5.3",
+      "resolved": "http://nue-repo-01.paesslergmbh.de:8081/repository/paessler-npm/axe-core/-/axe-core-3.5.3.tgz",
+      "integrity": "sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w=="
     },
     "babel-code-frame": {
       "version": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "vue-template-compiler": "^2.6.11"
   },
   "dependencies": {
-    "axe-core": "^3.4.1"
+    "axe-core": "3.5.3"
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,7 +31,7 @@ export function checkAndReport (options, node) {
   return deferred.promise
 }
 
-const standardResultHandler = function(error, results) {
+const standardResultHandler = function (errorInfo, results) {
   results.violations = results.violations.filter(result => {
     result.nodes = result.nodes.filter(node => {
       let key = node.target.toString() + result.id

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,34 +22,39 @@ export function checkAndReport (options, node) {
       console.clear()
     }
 
-    results.violations = results.violations.filter(result => {
-      result.nodes = result.nodes.filter(node => {
-        let key = node.target.toString() + result.id
-        let retVal = (!cache[key])
-        cache[key] = key
-        return retVal
-      })
-      return (!!result.nodes.length)
-    })
+    options.customResultHandler ? options.customResultHandler(error, results) : standardResultHandler(error, results)
 
-    if (results.violations.length) {
-      console.group('%cNew aXe issues', STYLE.head)
-      results.violations.forEach(result => {
-        let styl = IMPACT.hasOwnProperty(result.impact) ? IMPACT[result.impact] : IMPACT.minor
-        console.groupCollapsed('%c%s: %c%s %s', STYLE[styl], result.impact, STYLE.defaultReset, result.help, result.helpUrl)
-        result.nodes.forEach(function (node) {
-          failureSummary(node, 'any')
-          failureSummary(node, 'none')
-        })
-        console.groupEnd()
-      })
-      console.groupEnd()
-    }
     deferred.resolve()
 
     lastNotification = JSON.stringify(results.violations)
   })
   return deferred.promise
+}
+
+const standardResultHandler = function(error, results) {
+  results.violations = results.violations.filter(result => {
+    result.nodes = result.nodes.filter(node => {
+      let key = node.target.toString() + result.id
+      let retVal = (!cache[key])
+      cache[key] = key
+      return retVal
+    })
+    return (!!result.nodes.length)
+  })
+
+  if (results.violations.length) {
+    console.group('%cNew aXe issues', STYLE.head)
+    results.violations.forEach(result => {
+      let styl = IMPACT.hasOwnProperty(result.impact) ? IMPACT[result.impact] : IMPACT.minor
+      console.groupCollapsed('%c%s: %c%s %s', STYLE[styl], result.impact, STYLE.defaultReset, result.help, result.helpUrl)
+      result.nodes.forEach(function (node) {
+        failureSummary(node, 'any')
+        failureSummary(node, 'none')
+      })
+      console.groupEnd()
+    })
+    console.groupEnd()
+  }
 }
 
 export function resetCache () {


### PR DESCRIPTION
Hi there

# Which problems does this PR solve?
If the results of an `axe.run()` should be handled in a custom way this is currently not possible.

# More Context
I'm currently trying to integrate this library with my cypress e2e tests. Now in case of axe validation errors they are outputted to the console but there is no easy way to make the tests fail and output it to the cypress log. 

# Why use this implementation?
By implementing the `resultHandler` as an optional callback nothing of the original functionality is lost which means no breaking change. Also this ways anyone who wants to can handle the results the way he needs to
