### PR TITLE
fix: address typescript compile issues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export interface VueAxe
 {
     run({ clearConsole, element }: RunOptions): void;
 
-    plugins: Record<object>;
+    plugins: Record<string, any>;
 
     clearConsole(forceClear: boolean): void;
     
@@ -24,7 +24,7 @@ declare module 'vue/types/vue'
     }
 }
 
-declare class VueAxe
+export declare class VueAxe
 {
     static install: PluginFunction<never>;
 }


### PR DESCRIPTION
Currently if you use this in a TS project you'll get a series of errors.

**Example usage**:
```ts
import Vue from 'vue'

import VueAxe from 'vue-axe'
Vue.use(VueAxe)
```

<details>
<summary><strong>Resulting TypeScript error messages</strong></summary>

```
 ERROR  ERROR in /my-app/node_modules/vue-axe/index.d.ts(8,18):
8:18 Individual declarations in merged declaration 'VueAxe' must be all exported or all local.
     6 | }
     7 |
  >  8 | export interface VueAxe
       |                  ^
     9 | {
    10 |     run({ clearConsole, element }: RunOptions): void;
    11 |


 ERROR  ERROR in /my-app/node_modules/vue-axe/index.d.ts(12,14):
12:14 Generic type 'Record' requires 2 type argument(s).
    10 |     run({ clearConsole, element }: RunOptions): void;
    11 |
  > 12 |     plugins: Record<object>;
       |              ^
    13 |
    14 |     clearConsole(forceClear: boolean): void;
    15 |


 ERROR  ERROR in /my-app/node_modules/vue-axe/index.d.ts(27,15):
27:15 Individual declarations in merged declaration 'VueAxe' must be all exported or all local.
    25 | }
    26 |
  > 27 | declare class VueAxe
       |               ^
    28 | {
    29 |     static install: PluginFunction<never>;
    30 | }


 ERROR  ERROR in /my-app/packages/frontend/src/plugins/vue-axe.client.ts(8,17):
8:17 Property '$axe' does not exist on type 'VueConstructor<Vue>'.
    6 | Vue.use(VueAxe)
    7 |
  > 8 | console.log(Vue.$axe)
      |                 ^
    9 |
```
</details>

This PR fixes those.

Thanks for a great library!