### PR TITLE
feat: add option 'allowConsoleClears'

### DIFF
--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -23,7 +23,7 @@ To check manually, use [$axe.run](/guide/api.html#run)
 
 | Type     | Default  |
 | -------- | -------- |
-| Boolean  | `true`  | 
+| Boolean  | `true`   | 
 
 If false, disables all console clears (overriding `clearConsoleOnUpdate`).
 

--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -19,13 +19,27 @@ Vue.use(VueAxe, {
 To check manually, use [$axe.run](/guide/api.html#run)
 :::
 
+## allowConsoleClears
+
+| Type     | Default  |
+| -------- | -------- |
+| Boolean  | `true`  | 
+
+If false, disables all console clears (overriding `clearConsoleOnUpdate`).
+
+```js
+Vue.use(VueAxe, {
+  allowConsoleClears: false // disable all console clears 
+})
+```
+
 ## clearConsoleOnUpdate
 
 | Type     | Default  |
 | -------- | -------- |
 | Boolean  | `false`  | 
 
-If true, clean the console each time the component is updated.
+If true, clean the console each time the component is updated. No effect if `allowConsoleClears = false`.
 
 ```js
 Vue.use(VueAxe, {

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ export const draf = (cb) => requestAnimationFrame(() => requestAnimationFrame(cb
 
 export const defaultOptions = {
   auto: true,
+  allowConsoleClears: true,
   clearConsoleOnUpdate: false,
   delay: 500,
   config: {
@@ -31,7 +32,9 @@ export const defaultOptions = {
 export function clear (forceClear = false, options) {
   resetCache()
   if (forceClear || options.clearConsoleOnUpdate) {
-    console.clear()
     resetLastNotification()
+    if (options.allowConsoleClears) {
+      console.clear()
+    }
   }
 }


### PR DESCRIPTION
# Which problem does this PR solve?
https://github.com/vue-a11y/vue-axe/issues/28

When developing locally, developers sometimes utilize the console for helpful debug info. `vue-axe` should respect if developers don't want the console cleared.

No breaking changes since `allowConsoleClears` defaults to `true`. 

Let me know if you prefer a different name for `allowConsoleClears`.
