### PR TITLE
Add return value to customResultHandler field in VueAxeOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -135,7 +135,7 @@ export interface VueAxeOptions {
   /** 
    * Handle the results. (This may be needed for automated tests)
    */
-  customResultHandler?: (error: any, results: any);
+  customResultHandler?: (error: any, results: any) => any;
 }
 
 export interface VueAxe {


### PR DESCRIPTION
This PR fixes the bug described in #33. I haven't done any testing but I don't believe any is necessary for such a small change.